### PR TITLE
Implement chartjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "^17.2.0",
         "@angular/router": "^17.2.0",
         "bootstrap": "^5.3.3",
+        "chart.js": "^4.4.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -2812,6 +2813,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -4715,6 +4721,17 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.2.tgz",
+      "integrity": "sha512-6GD7iKwFpP5kbSD4MeRRRlTnQvxfQREy36uEtm1hzHzcOqwWx0YEHuspuoNlslu+nciLIB7fjjsHkUv/FzFcOg==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser-dynamic": "^17.2.0",
     "@angular/router": "^17.2.0",
     "bootstrap": "^5.3.3",
+    "chart.js": "^4.4.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/src/app/core/services/chart.service.ts
+++ b/src/app/core/services/chart.service.ts
@@ -1,37 +1,37 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { Department } from '../../shared/models/department.model';
-import { Chart } from '../../shared/models/chart.model';
+import { AlanChart } from '../../shared/models/alan-chart.model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ChartService {
 
-  private myUserCharts:Chart[] = []
+  private myUserCharts:AlanChart[] = []
 
   cardIsFullscreen: boolean = false;
 
   //BehaviorSubject holds and emits an array of charts the user has access to
-  userCharts = new BehaviorSubject<Chart[] | null>(this.myUserCharts);
+  userCharts = new BehaviorSubject<AlanChart[] | null>(this.myUserCharts);
 
   constructor() { }
 
-  addChart(chart:Chart){
+  addChart(chart:AlanChart){
     //if block prevents redundant chart addition
     if (!this.checkChartPresence(chart)){
       this.myUserCharts.push(chart);
     };
   }
 
-  removeChart(chart: Chart) {
+  removeChart(chart: AlanChart) {
     const index = this.myUserCharts.indexOf(chart);
     if (index !== -1) {
       this.myUserCharts.splice(index, 1);
     }
   }
 
-  checkChartPresence(chart:Chart){
+  checkChartPresence(chart:AlanChart){
     //returns true or false depending on whether chart is currently in array
     return this.myUserCharts.includes(chart);
   }
@@ -41,12 +41,6 @@ export class ChartService {
     return true;
   }
 
-  /* DEBUG
-
-  //Can be called to emit the value stored in myUserCharts
-  populateUserCharts(){
-    this.userCharts.next(this.myUserCharts);
-  } */
 
   toggleFullscreen(){
     this.cardIsFullscreen = !this.cardIsFullscreen
@@ -55,4 +49,12 @@ export class ChartService {
   checkFullscreen(): boolean{
     return this.cardIsFullscreen
   }
+
+  /* DEBUG
+
+  //Can be called to emit the value stored in myUserCharts
+  populateUserCharts(){
+    this.userCharts.next(this.myUserCharts);
+  } */
+
 }

--- a/src/app/core/services/department.service.ts
+++ b/src/app/core/services/department.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { Department } from '../../shared/models/department.model';
-import { Chart } from '../../shared/models/chart.model';
+import { AlanChart } from '../../shared/models/alan-chart.model';
 import { HttpDataService } from './http-data.service';
 
 
@@ -13,12 +13,12 @@ export class DepartmentService {
   // This is used to locally store the value to be emitted
   private myUserDepartments:Department[] = [
     new Department("Bobbles", [
-      new Chart("Bobble Sales", `
+      new AlanChart("Bobble Sales", `
         <body>
           <canvas id="myChart" width="400" height="400"></canvas>
         </body>
     `),
-      new Chart("Bobble Futures", `
+      new AlanChart("Bobble Futures", `
         <body>
           <canvas id="myChart" width="400" height="400"></canvas>
         </body>
@@ -26,7 +26,7 @@ export class DepartmentService {
     ]),
     new Department("Widgets", []),
     new Department("Wires", [
-      new Chart("Wire Shenanigans", `
+      new AlanChart("Wire Shenanigans", `
       <body>
         <canvas id="myChart" width="400" height="400"></canvas>
       </body>

--- a/src/app/core/services/department.service.ts
+++ b/src/app/core/services/department.service.ts
@@ -10,26 +10,65 @@ import { HttpDataService } from './http-data.service';
 })
 export class DepartmentService {
 
+  //Currently this is holding hardcoded data for the sake of engaging the app. We will populate this data with an HTTP request
+  
   // This is used to locally store the value to be emitted
   private myUserDepartments:Department[] = [
     new Department("Bobbles", [
       new AlanChart("Bobble Sales", `
-        <body>
-          <canvas id="myChart" width="400" height="400"></canvas>
-        </body>
+      {
+        "type": "line",
+        "data": {
+          "labels": ["R", "O", "Y", "G", "B", "I", "V"],
+          "datasets": [{
+            "label": "An Example Data",
+            "data": [65, 59, 80, 81, 90, 92, 96],
+            "fill": false,
+            "borderColor": "rgb(0, 255, 0)",
+            "tension": 0.1
+          }]
+        }
+      }
     `),
       new AlanChart("Bobble Futures", `
-        <body>
-          <canvas id="myChart" width="400" height="400"></canvas>
-        </body>
+      {
+        "type": "line",
+        "data": {
+          "labels": ["R", "O", "Y", "G", "B", "I", "V"],
+          "datasets": [{
+            "label": "An Example Data",
+            "data": [65, 59, 80, 81, 56, 55, 40],
+            "fill": false,
+            "borderColor": "rgb(255, 0, 0)",
+            "tension": 0.1
+          }]
+        }
+      }
     `),
     ]),
     new Department("Widgets", []),
     new Department("Wires", [
       new AlanChart("Wire Shenanigans", `
-      <body>
-        <canvas id="myChart" width="400" height="400"></canvas>
-      </body>
+      {
+        "type": "bar",
+        "data": {
+          "labels": ["January", "February", "March", "April", "May", "June", "July"],
+          "datasets": [{
+            "label": "Monthly Sales",
+            "data": [65, 59, 80, 81, 56, 55, 40],
+            "backgroundColor": "rgba(54, 162, 235, 0.2)",
+            "borderColor": "rgba(54, 162, 235, 1)",
+            "borderWidth": 1
+          }]
+        },
+        "options": {
+          "scales": {
+            "y": {
+              "beginAtZero": true
+            }
+          }
+        }
+      }
   `)]
   )];
 

--- a/src/app/core/services/http-data.service.ts
+++ b/src/app/core/services/http-data.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Department } from '../../shared/models/department.model';
 import { Observable, catchError, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment.development';
-import { Chart } from '../../shared/models/chart.model';
+import { AlanChart } from '../../shared/models/alan-chart.model';
 
 @Injectable({
   providedIn: 'root'
@@ -18,14 +18,14 @@ export class HttpDataService {
     )
   }
 
-  getUserCharts(id:number): Observable<Chart[]> {
-    return this.http.get<Chart[]>(`${environment.apiUrl}/user/${id}/user_charts`).pipe(
+  getUserCharts(id:number): Observable<AlanChart[]> {
+    return this.http.get<AlanChart[]>(`${environment.apiUrl}/user/${id}/user_charts`).pipe(
       catchError(this.handleError)
     )
   }
 
   addUserCharts(id:number, data:any) {
-    return this.http.post<Chart[]>(`${environment.apiUrl}/user/${id}/user_charts`, data).pipe(
+    return this.http.post<AlanChart[]>(`${environment.apiUrl}/user/${id}/user_charts`, data).pipe(
       catchError(this.handleError)
     )
   }
@@ -40,7 +40,7 @@ export class HttpDataService {
   }
 
   addUserDepartments(id:number, data:any) {
-    return this.http.post<Chart[]>(`${environment.apiUrl}/user/${id}/user_department`, data).pipe(
+    return this.http.post<AlanChart[]>(`${environment.apiUrl}/user/${id}/user_department`, data).pipe(
       catchError(this.handleError)
     )
   }

--- a/src/app/shared/components/chart-display/chart-card/chart-card.component.html
+++ b/src/app/shared/components/chart-display/chart-card/chart-card.component.html
@@ -3,9 +3,9 @@
     <div>
       <div class="card">
         <div class="card-body">
-          <div [innerHTML]="chartFromParent?.chart_data"></div>
+          <div [innerHTML]="chartFromParent.chart_data"></div>
           <canvas id="myChart" width="200" height="200" style="border: 1px solid #000;"></canvas>
-          <h5 class="card-title">{{chartFromParent?.chart_title}}</h5>
+          <h5 class="card-title">{{chartFromParent.chart_title}}</h5>
           <div class="d-flex justify-content-between">
             <img src="../../../../../assets/svg/open_in_full.svg" alt="FullScreen" (click)="makeFullscreen()" class="fullIcon">
             <img src="../../../../../assets/svg/close.svg" alt="Remove" (click)="removeChart(chartFromParent)" class="removeIcon">

--- a/src/app/shared/components/chart-display/chart-card/chart-card.component.html
+++ b/src/app/shared/components/chart-display/chart-card/chart-card.component.html
@@ -1,10 +1,32 @@
-<div class="container" [id]="cardIndex">
+@if (isFullscreen()) {
+  <div class="container">
+    <div class="row">
+      <div>
+        <div class="card">
+          <div class="card-body">
+            <canvas id="ctx" width="200" height="200" style="border: 1px solid #000; background-color: darkorchid;" ></canvas>
+            <h5 class="card-title">{{chartFromParent.chart_title}}</h5>
+            <div class="d-flex justify-content-between">
+              <img src="../../../../../assets/svg/open_in_full.svg" alt="FullScreen" (click)="makeFullscreen()" class="fullIcon">
+              <img src="../../../../../assets/svg/close.svg" alt="Remove" (click)="removeChart(chartFromParent)" class="removeIcon">
+              <!-- <button class="btn btn-primary" (click)="makeFullscreen()">Fullscreen</button>
+              <button type="button" class="btn btn-danger" (click)="removeChart(chartFromParent)">Remove</button> -->
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- You can add more card elements here -->
+
+    </div>
+  </div>
+} @else {
+<div class="container">
   <div class="row">
     <div>
       <div class="card">
         <div class="card-body">
-          <div [innerHTML]="chartFromParent.chart_data"></div>
-          <canvas id="myChart" width="200" height="200" style="border: 1px solid #000;"></canvas>
+          <canvas id="ctx{{cardIndex}}" width="200" height="200" style="border: 1px solid #000; background-color: darkorchid;" ></canvas>
           <h5 class="card-title">{{chartFromParent.chart_title}}</h5>
           <div class="d-flex justify-content-between">
             <img src="../../../../../assets/svg/open_in_full.svg" alt="FullScreen" (click)="makeFullscreen()" class="fullIcon">
@@ -20,3 +42,4 @@
 
   </div>
 </div>
+}

--- a/src/app/shared/components/chart-display/chart-card/chart-card.component.ts
+++ b/src/app/shared/components/chart-display/chart-card/chart-card.component.ts
@@ -1,7 +1,7 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, Output } from '@angular/core';
 import { AlanChart } from '../../../models/alan-chart.model';
 import { ChartService } from '../../../../core/services/chart.service';
-import { SidebarService } from '../../../../core/services/sidebar.service';
+import { Chart, ChartConfiguration } from 'chart.js/auto';
 
 @Component({
   selector: 'app-chart-card',
@@ -10,7 +10,7 @@ import { SidebarService } from '../../../../core/services/sidebar.service';
   templateUrl: './chart-card.component.html',
   styleUrl: './chart-card.component.scss'
 })
-export class ChartCardComponent implements OnInit {
+export class ChartCardComponent implements AfterViewInit {
   @Input() chartFromParent!: AlanChart;
   @Input() cardIndex!: number;
   @Output() fullscreenChart = new EventEmitter<AlanChart>();
@@ -19,6 +19,24 @@ export class ChartCardComponent implements OnInit {
     private chartService:ChartService,
   ){}
 
+  //In order for the cardIndex binding work properly, we have to use ngAfterViewInit
+  //This renders the charts after the components are built, which is important here
+  ngAfterViewInit(): void {
+    //This unpacks the chart_data from our AlanChart as an object
+    let chartConfig:ChartConfiguration = JSON.parse(this.chartFromParent.chart_data);
+    //We have to check for fullscreen since charts rerender on enlarging
+    if (this.isFullscreen()) {
+      //in fullscreen mode, the canvas identifier is simply 'ctx'
+      let chartItem = "ctx";
+      //chartItem is a reference to the canvas to render in, chartConfig is a configuration object for ChartJS
+      new Chart(chartItem, chartConfig);
+    } else {
+      //when displaying multiple charts we have to procedurally count up for each canvas rendered and match its id
+      let chartItem = "ctx" + this.cardIndex.toString();
+      new Chart(chartItem, chartConfig);
+    }
+  }
+
   removeChart(chart:AlanChart | null){
     //Checks for truthy to enforce type safety
     if(chart){
@@ -26,14 +44,15 @@ export class ChartCardComponent implements OnInit {
     }
   }
 
-  ngOnInit(): void {
-    //We are going to need some fancy code here to get this to render anything other than raw HTML
-    //But it can be done.
-  }
 
   makeFullscreen(){
     this.chartService.toggleFullscreen()
     this.fullscreenChart.emit(this.chartFromParent)
+  }
+
+  //We needed a check here to render fullscreen correctly
+  isFullscreen(){
+    return this.chartService.checkFullscreen()
   }
 
 }

--- a/src/app/shared/components/chart-display/chart-card/chart-card.component.ts
+++ b/src/app/shared/components/chart-display/chart-card/chart-card.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { Chart } from '../../../models/chart.model';
+import { AlanChart } from '../../../models/alan-chart.model';
 import { ChartService } from '../../../../core/services/chart.service';
 import { SidebarService } from '../../../../core/services/sidebar.service';
 
@@ -11,15 +11,15 @@ import { SidebarService } from '../../../../core/services/sidebar.service';
   styleUrl: './chart-card.component.scss'
 })
 export class ChartCardComponent implements OnInit {
-  @Input() chartFromParent!: Chart;
+  @Input() chartFromParent!: AlanChart;
   @Input() cardIndex!: number;
-  @Output() fullscreenChart = new EventEmitter<Chart>();
+  @Output() fullscreenChart = new EventEmitter<AlanChart>();
 
   constructor(
     private chartService:ChartService,
   ){}
 
-  removeChart(chart:Chart | null){
+  removeChart(chart:AlanChart | null){
     //Checks for truthy to enforce type safety
     if(chart){
     this.chartService.removeChart(chart);

--- a/src/app/shared/components/chart-display/chart-display.component.ts
+++ b/src/app/shared/components/chart-display/chart-display.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit, Output } from '@angular/core';
 import { ChartCardComponent } from './chart-card/chart-card.component';
-import { Chart } from '../../models/chart.model';
+import { AlanChart } from '../../models/alan-chart.model';
 import { ChartService } from '../../../core/services/chart.service';
 import { Subscription } from 'rxjs';
 import { SidebarService } from '../../../core/services/sidebar.service';
@@ -13,10 +13,10 @@ import { SidebarService } from '../../../core/services/sidebar.service';
   styleUrl: './chart-display.component.scss'
 })
 export class ChartDisplayComponent implements OnInit, OnDestroy {
-  fullChart!: Chart;
+  fullChart!: AlanChart;
   private userChartSubscription!:Subscription;
   //filler data until set with behavior subject
-  charts!:Chart[]| null;
+  charts!:AlanChart[]| null;
 
   constructor(
     private chartService:ChartService,
@@ -48,7 +48,7 @@ export class ChartDisplayComponent implements OnInit, OnDestroy {
     return this.chartService.checkFullscreen()
   }
 
-  displayFullChart(chartData: Chart){
+  displayFullChart(chartData: AlanChart){
     this.fullChart = chartData
   }
 }

--- a/src/app/shared/components/chart-display/chart-display.component.ts
+++ b/src/app/shared/components/chart-display/chart-display.component.ts
@@ -22,12 +22,6 @@ export class ChartDisplayComponent implements OnInit, OnDestroy {
     private chartService:ChartService,
     private sidebar:SidebarService){}
 
-  //EXPIREMENTAL NONSENSE
-  // setSize(number:number){
-  //     let bootstrapSize = Math.floor(Math.random() * (8 - 4 + 1)) + 4;
-  //     return `col-${bootstrapSize}`
-  // }
-
 
   ngOnInit(): void {
     // Populates localcomponent charts[] to be rendered in this component's for loop
@@ -49,6 +43,6 @@ export class ChartDisplayComponent implements OnInit, OnDestroy {
   }
 
   displayFullChart(chartData: AlanChart){
-    this.fullChart = chartData
+    this.fullChart = chartData;
   }
 }

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { DepartmentService } from '../../../core/services/department.service';
 import { Subscription } from 'rxjs';
 import { Department } from '../../models/department.model';
-import { Chart } from '../../models/chart.model';
+import { AlanChart } from '../../models/alan-chart.model';
 import { ChartService } from '../../../core/services/chart.service';
 import { SidebarService } from '../../../core/services/sidebar.service';
 
@@ -51,11 +51,11 @@ export class SidebarComponent implements OnInit, OnDestroy{
   }
 
   //Adds the selected chart
-  addChart(chart:Chart) {
+  addChart(chart:AlanChart) {
     this.chartService.addChart(chart);
   }
 
-  checkChartStatus(chart:Chart){
+  checkChartStatus(chart:AlanChart){
     return this.chartService.checkChartPresence(chart);
   }
 

--- a/src/app/shared/models/alan-chart.model.ts
+++ b/src/app/shared/models/alan-chart.model.ts
@@ -1,10 +1,9 @@
-export class Chart {
+export class AlanChart {
   public chart_title: string;
   public chart_data: string;
 
   constructor(chart_title:string, chart_data:string){
     this.chart_title = chart_title;
     this.chart_data = chart_data;
-
   }
 }

--- a/src/app/shared/models/alan-chart.model.ts
+++ b/src/app/shared/models/alan-chart.model.ts
@@ -1,4 +1,8 @@
 export class AlanChart {
+  //Inorder to function properly, an AlanChart has a chart_title and a chart_data, both of which are strings
+  //VERY IMPORTANT: chart_data is a Chart.js chart configuration saved as a JSON string
+  //This ensures it goes smoothly into the rails DB as a text blob. We unpack it on this side in components where charts are rendered
+
   public chart_title: string;
   public chart_data: string;
 

--- a/src/app/shared/models/department.model.ts
+++ b/src/app/shared/models/department.model.ts
@@ -1,10 +1,10 @@
-import { Chart } from "./chart.model";
+import { AlanChart } from "./alan-chart.model";
 
 export class Department {
   public department_name: string;
-  public chart_array: Chart[];
+  public chart_array: AlanChart[];
 
-  constructor(department_name:string, chart_array:Chart[]){
+  constructor(department_name:string, chart_array:AlanChart[]){
     this.department_name = department_name;
     this.chart_array = chart_array;
   }


### PR DESCRIPTION
This one's pretty big.  I changed what we were calling Chart to a type called AlanChart to avoid conflicts with Chart from Chart.js  That change affected a lot of files which I chased down and rectified.  

Then there were many things that had to happen in chart-card.component.ts to ensure that charts rendered correctly and at the correct time. Much of this was fairly arcane, so I commented the methods so that everyone can follow along with the logic that it took to get it done.  That ngAfterViewInit() is the guts of it.  If you try to put the same method in ngOnInit() it only renders the first chart and none of the subsequent ones. Actually kind of cool, I learned a lot about the lifecycle hooks.  

At any rate, give it a look. I would really encourage us to merge this before working on more front end.  Primarily because that AlanChart thing will make your merges a headache if you're branching at a point before this merger. Ultimately I'm really pleased with how it's working. 